### PR TITLE
FIX call the correct function for mail type send

### DIFF
--- a/mailcertificado/api.py
+++ b/mailcertificado/api.py
@@ -301,7 +301,7 @@ class MailCertificado(object):
                          'smsBody': sms_body})
 
         try:
-            res = connection.service.sendAgreementWS(data)
+            res = connection.service.sendMailWS(data)
             if res is None:
                 self.exception('unknown')
             res = res.result[0].messageId[0]


### PR DESCRIPTION
Call the correct function send mail from mailcertificado api for the mail type "mail"